### PR TITLE
fix(port): changes expose port from 8083 to 5299

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8083
+EXPOSE 5299
 VOLUME /books /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -50,5 +50,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8083
+EXPOSE 5299
 VOLUME /books /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -50,5 +50,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 8083
+EXPOSE 5299
 VOLUME /books /config


### PR DESCRIPTION
Hi Lazylibrarian runs on port 5299 but the Dockerfiles expose port 8083. I couldn't find a reason why so I made a pull request with a fix. If I should change something let me know

Thx, asdftemp

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

