### PR TITLE
resolve missing libnss3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
     ghostscript \
     libjpeg-turbo8 \
     libmagic1 \
+    libnss3-dev \
     python3-venv \
     zlib1g && \
   echo "**** install app ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -22,6 +22,7 @@ RUN \
     ghostscript \
     libjpeg-turbo8 \
     libmagic1 \
+    libnss3-dev \
     python3-venv \
     zlib1g && \
   echo "**** install app ****" && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/docker-lazylibrarian/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
error reported in another discord
```
____________________ WARNING ____________________
Setting up completion failed with error:
__________________________________________________
Failed to import PyQt module: PyQt6.QtWebEngineCore with error: libnss3.so: cannot open shared object file: No such file or directory
    Traceback (most recent call last):
      File "calibre/linux.py", line 837, in setup_completion
      File "calibre/linux.py", line 587, in write_completion
      File "bypy-importer.py", line 279, in exec_module
      File "calibre/gui2/tweak_book/main.py", line 12, in <module>
      File "bypy-importer.py", line 279, in exec_module
      File "calibre/ebooks/oeb/polish/check/css.py", line 11, in <module>
    ImportError: cannot import name 'QWebEnginePage' from 'qt.webengine' (/app/calibre/lib/calibre-extensions/python-lib.bypy.frozen/qt/webengine.pyc)
Setting up desktop integration...
```
## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
resolve error shown above
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
super helpful, but filthy portainer scumbag tested this and confirmed the fix after alerting me to the error (and another error)

```
**** ffmpeg already installed, skipping ****
**** Adding calibre dependencies to package install list ****
[mod-init] **** Installing all mod packages ****
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu jammy-security InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
libxdamage1 is already the newest version (1:1.1.5-2build2).
0 upgraded, 0 newly installed, 0 to remove and 6 not upgraded.
**** Calibre already installed, skipping ****
[custom-init] No custom files found, skipping...
2023-10-17 02:39:03,635 DEBUG: Set config[CONFIG_TAB_NUM]=2 [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,635 DEBUG: Set config[DOWNLOAD_DIR]=/downloads [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,635 DEBUG: Set config[LOGDIR]=/config/log [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,635 DEBUG: Set config[SERVER_ID]=[Redacted] [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,635 DEBUG: Set config[TELEMETRY_SERVER]=https://lazylibrarian.telem.ch [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,635 DEBUG: Set config[TELEMETRY_ENABLE]=True [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,636 DEBUG: Set config[INSTALL_TYPE]=source [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,636 DEBUG: Set config[CURRENT_VERSION]=b40bef6b [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,636 DEBUG: Set config[LATEST_VERSION]=b40bef6b918b4890aca33fe093331f459a8baae1 [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,636 DEBUG: Set config[AUDIOBOOK_DEST_FOLDER]=$Author/$Title [configtypes.py:160 (MAIN/special.configwrite)]
2023-10-17 02:39:03,639 DEBUG: Read config[LOGDIR]=/config/log [configtypes.py:144 (MAIN)]
2023-10-17 02:39:03,656 DEBUG: Read config[LOGSPECIALDEBUG]= [configtypes.py:144 (MAIN)]
/app/lazylibrarian/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'bootswatch.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
[ls.io-init] done.
/app/lazylibrarian/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'lazylibrarian.telem.ch'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
```